### PR TITLE
Made Step 1 Flag organisations as in Re-verification process.

### DIFF
--- a/FSSStepFunction/V1/Errors/ResourceNotFound.cs
+++ b/FSSStepFunction/V1/Errors/ResourceNotFound.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace LbhFssStepFunction.V1.Errors
+{
+    public class ResourceNotFoundException : Exception
+    {
+        public ResourceNotFoundException(string message) : base(message) {}
+    }
+}

--- a/FSSStepFunction/V1/Gateways/Interface/IOrganisationsGateway.cs
+++ b/FSSStepFunction/V1/Gateways/Interface/IOrganisationsGateway.cs
@@ -8,5 +8,6 @@ namespace LbhFssStepFunction.V1.Gateways.Interface
         OrganisationDomain GetOrganisationById(int id);
         List<OrganisationDomain> GetOrganisationsToReview();
         OrganisationDomain PauseOrganisation(int id);
+        void FlagOrganisationToBeInRevalidation(int id);
     }
 }

--- a/FSSStepFunction/V1/UseCase/FirstStepUseCase.cs
+++ b/FSSStepFunction/V1/UseCase/FirstStepUseCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using LbhFssStepFunction.V1.Errors;
 using LbhFssStepFunction.V1.Factories;
 using LbhFssStepFunction.V1.Gateways;
 using LbhFssStepFunction.V1.Gateways.Interface;
@@ -23,12 +24,22 @@ namespace LbhFssStepFunction.V1.UseCase
         public async Task<OrganisationResponse> GetOrganisationAndSendEmail(int id)
         {
             LoggingHandler.LogInfo("Executing request to gateway to get organisation");
-            var organisationDomain = _organisationsGateway.GetOrganisationById(id);
-            if (organisationDomain == null)
+
+            try {
+                _organisationsGateway.FlagOrganisationToBeInRevalidation(id);
+            } catch (ResourceNotFoundException ex) {
+                LoggingHandler.LogInfo($"{ex.Message}\n\nTerminating First Step Function.");
                 return null;
+            }
+
+            // any retrieved organisation shouldn't be "null" at this point, because if it was, then the
+            // code would have terminated on line 32.
+            var organisationDomain = _organisationsGateway.GetOrganisationById(id);
             var organisation = organisationDomain.ToResponse();
+
             await _notifyGateway.SendNotificationEmail(organisation.OrganisationName, organisation.EmailAddresses.ToArray(), 1).ConfigureAwait(true);
             organisation.StateResult = true;
+            
             //ToDo: Change AddSeconds to AddDays
             organisation.NextStepTime = DateTime.Now.AddSeconds(Int32.Parse(_waitDuration));
             return organisation;

--- a/LbhFssStepFunction.Tests/HandlerTests.cs
+++ b/LbhFssStepFunction.Tests/HandlerTests.cs
@@ -43,21 +43,30 @@ namespace LbhFssStepFunction.Tests
         }
 
         [TestCase(TestName = "Given that the first step function gets called, it calls the first step use case GetOrganisationAndSendEmail method.")]
-        public void FirstStepHandlerCallsFirstStepUseCase()
+        public async Task FirstStepHandlerCallsFirstStepUseCase()
         {
             var request = _fixture.Create<OrganisationRequest>();
-            _classUnderTest.FirstStep(request);
+            await _classUnderTest.FirstStep(request);
             _mockFirstStepUseCase.Verify(uc =>
                 uc.GetOrganisationAndSendEmail(It.Is<int>(x => x == request.OrganisationId)), Times.Once);
         }
 
-        [TestCase(TestName = "Given that the first step function gets called with a valid organisation id, it returns an Organisation Response.")]
+        [TestCase(TestName = @"
+            Given a valid organisation id,
+            When the first step function gets called,
+            Then it returns an Organisation Response.")]
         public async Task FirstStepHandlerReturnsOrganisationResponse()
         {
+            // arrange
             var request = _fixture.Create<OrganisationRequest>();
             var expectedResponse = _fixture.Create<OrganisationResponse>();
+            
             _mockFirstStepUseCase.Setup(x => x.GetOrganisationAndSendEmail(It.IsAny<int>())).ReturnsAsync(expectedResponse);
+            
+            // act
             var response = await _classUnderTest.FirstStep(request);
+
+            // assert
             response.Should().Be(expectedResponse);
         }
 

--- a/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
@@ -1,9 +1,11 @@
+using System.Threading.Tasks;
 using LbhFssStepFunction.Tests.TestHelpers;
 using LbhFssStepFunction.V1.Factories;
 using LbhFssStepFunction.V1.Gateways.Interface;
 using LbhFssStepFunction.V1.UseCase;
 using Moq;
 using NUnit.Framework;
+using System;
 
 namespace LbhFssStepFunction.Tests.V1.UseCase
 {
@@ -17,24 +19,37 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         [SetUp]
         public void Setup()
         {
+            Environment.SetEnvironmentVariable("WAIT_DURATION", "600");
             _mockOrganisationGateway = new Mock<IOrganisationsGateway>();
             _mockNotifyGateway = new Mock<INotifyGateway>();
             _classUnderTest = new FirstStepUseCase(_mockOrganisationGateway.Object, _mockNotifyGateway.Object);
         }
 
-        [TestCase(TestName = "Given that the first step use case gets called, it calls the organisation gateway GetOrganisationsToReview method.")]
-        public void FirstStepUseCaseCallsOrganisationGateway()
+        [TestCase(TestName = @"
+            Given that the first step use case gets called,
+            It calls the organisation gateway GetOrganisationsToReview method.")]
+        public async Task FirstStepUseCaseCallsOrganisationGateway()
         {
-            _classUnderTest.GetOrganisationAndSendEmail(1);
+            // act
+            await _classUnderTest.GetOrganisationAndSendEmail(1);
+            
+            // assert
             _mockOrganisationGateway.Verify(gw => gw.GetOrganisationById(It.IsAny<int>()), Times.Once);
         }
 
-        [TestCase(TestName = "Given that the first step use case gets called, it calls the notify gateway SendNotificationEmail method.")]
-        public void FirstStepUseCaseCallsNotificationGateway()
+        [TestCase(TestName = @"
+            Given that the first step use case gets called,
+            It calls the notify gateway SendNotificationEmail method.")]
+        public async Task FirstStepUseCaseCallsNotificationGateway()
         {
+            // arrange
             var organisation = EntityHelpers.CreateOrganisation();
             _mockOrganisationGateway.Setup(og => og.GetOrganisationById(It.IsAny<int>())).Returns(organisation.ToDomain());
-            _classUnderTest.GetOrganisationAndSendEmail(1);
+
+            // act
+            await _classUnderTest.GetOrganisationAndSendEmail(1);
+            
+            // assert
             _mockNotifyGateway.Verify(gw => gw.SendNotificationEmail(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<int>()), Times.Once);
         }
 

--- a/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
@@ -32,6 +32,10 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             It calls the organisation gateway GetOrganisationsToReview method.")]
         public async Task FirstStepUseCaseCallsOrganisationGateway()
         {
+            // arrange
+            _mockOrganisationGateway.Setup(
+                gw => gw.GetOrganisationById(It.IsAny<int>())).Returns(EntityHelpers.CreateOrganisation().ToDomain());
+            
             // act
             await _classUnderTest.GetOrganisationAndSendEmail(1);
             
@@ -66,9 +70,10 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         {
             // arrange
             int randomOrgId = Randomm.Id(100, 200);
+            _mockOrganisationGateway.Setup(
+                gw => gw.GetOrganisationById(It.IsAny<int>())).Returns(EntityHelpers.CreateOrganisation().ToDomain());
 
             // act
-            // _mockOrganisationGateway.Setup(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()));
             await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
 
             // assert
@@ -85,7 +90,7 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             int randomOrgId = Randomm.Id(100, 200);
             _mockOrganisationGateway.Setup(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()))
                 .Throws(new ResourceNotFoundException("Error"));
-
+            
             // act
             var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
 

--- a/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
@@ -6,6 +6,8 @@ using LbhFssStepFunction.V1.UseCase;
 using Moq;
 using NUnit.Framework;
 using System;
+using LbhFssStepFunction.V1.Errors;
+using FluentAssertions;
 
 namespace LbhFssStepFunction.Tests.V1.UseCase
 {
@@ -53,5 +55,43 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             _mockNotifyGateway.Verify(gw => gw.SendNotificationEmail(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<int>()), Times.Once);
         }
 
+        // There should be a test case for UC return, but the current return doesn't make sense.
+        // Will look into refactoring in the future.
+
+        [TestCase(TestName = @"
+            Given an existing organisation's Id (GW mock will not throw an error),
+            When the first step usecase's GetOrganisationAndSendEmail method is called,
+            Then the secondary call to FlagOrganisationToBeInRevalidation organition gateway's method is made")]
+        public async Task FirstStepUCCallsFlagOrgMethod()
+        {
+            // arrange
+            int randomOrgId = Randomm.Id(100, 200);
+
+            // act
+            // _mockOrganisationGateway.Setup(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()));
+            await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
+
+            // assert
+            _mockOrganisationGateway.Verify(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()), Times.Once);
+        }
+
+        [TestCase(TestName = @"
+            Given an existing organisation's Id (GW mock will not throw an error),
+            When the first step usecase's GetOrganisationAndSendEmail method is called,
+            Then the secondary call to FlagOrganisationToBeInRevalidation organition gateway's method is made")]
+        public async Task FirstStepUCReturnsNullWhenFlagOrgMethodThrowsResourceNotFound()
+        {
+            // arrange
+            int randomOrgId = Randomm.Id(100, 200);
+            _mockOrganisationGateway.Setup(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()))
+                .Throws(new ResourceNotFoundException("Error"));
+
+            // act
+            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
+
+            // assert
+            _mockOrganisationGateway.Verify(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()), Times.Once);
+            ucResult.Should().Be(null);
+        }
     }
 }


### PR DESCRIPTION
# What:
 - Made the first step of the Step Function flag the organisation to be in revalidation/reverification process.

# Why:
 - Information about the support organisation and its services should be updated yearly to ensure that information on the FSS website and system is describing the provided services correctly. After a year since last update passes, the organisation record needs to be put into InRevalidation state so that it could be easily distinguished from more up-to-date records.

# Notes:
 - Also improved a couple of First Step related tests - made them explicitly await the UC and Handler calls before attempting to verify anything.