### PR TITLE
Hopefully, Remaining steps

### DIFF
--- a/FSSStepFunction/V1/Gateways/Interface/IOrganisationsGateway.cs
+++ b/FSSStepFunction/V1/Gateways/Interface/IOrganisationsGateway.cs
@@ -7,7 +7,7 @@ namespace LbhFssStepFunction.V1.Gateways.Interface
     {
         OrganisationDomain GetOrganisationById(int id);
         List<OrganisationDomain> GetOrganisationsToReview();
-        OrganisationDomain PauseOrganisation(int id);
+        void PauseOrganisation(int id);
         void FlagOrganisationToBeInRevalidation(int id);
     }
 }

--- a/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
+++ b/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
@@ -46,7 +46,7 @@ namespace LbhFssStepFunction.V1.Gateways
         {
             var orgsToReview = _context.Organisations
                 .Where(x => x.LastRevalidation < DateTime.Today.AddDays(-365))
-                .Where(x => x.InRevalidationProcess == false)
+                .Where(x => !x.InRevalidationProcess)
                 .Where(x => x.Status.ToLower() == "published")
                 .Select(org => org.ToDomain())
                 .ToList();

--- a/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
+++ b/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
@@ -53,7 +53,7 @@ namespace LbhFssStepFunction.V1.Gateways
             return orgsToReview;
         }
 
-        public OrganisationDomain PauseOrganisation(int id)
+        public void PauseOrganisation(int id)
         {
             var organisationToPause = _context.Organisations.Find(id);
 
@@ -63,9 +63,6 @@ namespace LbhFssStepFunction.V1.Gateways
             organisationToPause.Status = "Paused";
             // _context.Organisations.Attach(organisationToPause);
             _context.SaveChanges();
-
-            var org = _context.Organisations.Find(id);
-            return org.ToDomain();
         }
 
         public void FlagOrganisationToBeInRevalidation(int id)

--- a/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
+++ b/FSSStepFunction/V1/Gateways/OrganisationsGateway.cs
@@ -55,10 +55,15 @@ namespace LbhFssStepFunction.V1.Gateways
 
         public OrganisationDomain PauseOrganisation(int id)
         {
-            var orgToPause = _context.Organisations.Find(id);
-            orgToPause.Status = "Paused";
-            _context.Organisations.Attach(orgToPause);
+            var organisationToPause = _context.Organisations.Find(id);
+
+            if (organisationToPause == null)
+                throw new ResourceNotFoundException($"Organisation with id={id} was not found.");
+
+            organisationToPause.Status = "Paused";
+            // _context.Organisations.Attach(organisationToPause);
             _context.SaveChanges();
+
             var org = _context.Organisations.Find(id);
             return org.ToDomain();
         }

--- a/FSSStepFunction/V1/UseCase/FirstStepUseCase.cs
+++ b/FSSStepFunction/V1/UseCase/FirstStepUseCase.cs
@@ -37,7 +37,13 @@ namespace LbhFssStepFunction.V1.UseCase
             var organisationDomain = _organisationsGateway.GetOrganisationById(id);
             var organisation = organisationDomain.ToResponse();
 
-            await _notifyGateway.SendNotificationEmail(organisation.OrganisationName, organisation.EmailAddresses.ToArray(), 1).ConfigureAwait(true);
+            await _notifyGateway
+                .SendNotificationEmail(
+                    organisation.OrganisationName, 
+                    organisation.EmailAddresses.ToArray(),
+                    1)
+                .ConfigureAwait(true);
+                
             organisation.StateResult = true;
             
             //ToDo: Change AddSeconds to AddDays

--- a/FSSStepFunction/V1/UseCase/PauseStepUseCase.cs
+++ b/FSSStepFunction/V1/UseCase/PauseStepUseCase.cs
@@ -23,10 +23,10 @@ namespace LbhFssStepFunction.V1.UseCase
             var org = _organisationsGateway.GetOrganisationById(id);
             if (org == null)
                 return null;
-            var updatedOrg = _organisationsGateway.PauseOrganisation(org.Id);
-            if (updatedOrg == null)
-                return null;
-            var organisation = updatedOrg.ToResponse();
+            
+            _organisationsGateway.PauseOrganisation(org.Id);
+
+            var organisation = org.ToResponse();
             await _notifyGateway.SendNotificationEmail(organisation.OrganisationName, organisation.EmailAddresses.ToArray(), 4).ConfigureAwait(true);
             return organisation;
         }

--- a/FSSStepFunction/V1/UseCase/PauseStepUseCase.cs
+++ b/FSSStepFunction/V1/UseCase/PauseStepUseCase.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Threading.Tasks;
+using LbhFssStepFunction.V1.Errors;
 using LbhFssStepFunction.V1.Factories;
 using LbhFssStepFunction.V1.Gateways;
 using LbhFssStepFunction.V1.Gateways.Interface;
@@ -19,16 +21,58 @@ namespace LbhFssStepFunction.V1.UseCase
         }
         public async Task<OrganisationResponse> GetOrganisationAndSendEmail(int id)
         {
-            LoggingHandler.LogInfo("Second step executing request to gateway to get organisation");
-            var org = _organisationsGateway.GetOrganisationById(id);
-            if (org == null)
-                return null;
+            try {
+                LoggingHandler.LogInfo("Second step executing request to gateway to get organisation");
             
-            _organisationsGateway.PauseOrganisation(org.Id);
+                var organisation = _organisationsGateway.GetOrganisationById(id);
+                
+                if (organisation == null)
+                {
+                    LoggingHandler.LogInfo($"Organisation with id={id} was not found!");
+                    return null;
+                }
+                else if (!organisation.InRevalidationProcess)
+                {
+                    LoggingHandler.LogInfo($"Organisation with id={id} has been reverified since Step 3 execution.");
+                    return null;
+                }
+                else
+                {
+                    LoggingHandler.LogInfo($"Organisation with id={id} was found, attempting to pause it.");
+                    _organisationsGateway.PauseOrganisation(organisation.Id);
 
-            var organisation = org.ToResponse();
-            await _notifyGateway.SendNotificationEmail(organisation.OrganisationName, organisation.EmailAddresses.ToArray(), 4).ConfigureAwait(true);
-            return organisation;
+                    var response = organisation.ToResponse();
+
+                    await _notifyGateway
+                        .SendNotificationEmail(
+                            response.OrganisationName,
+                            response.EmailAddresses.ToArray(),
+                            4)
+                        .ConfigureAwait(true);
+
+                    LoggingHandler.LogInfo($"Organisation with id={id} was paused, exiting Pause Step use case");
+
+                    response.StateResult = true; // symbollic return
+
+                    return response;
+                }
+            }
+            // blocks could be used to execute custom logic, however, not much can be done while exception handling
+            // approach hasn't yet been discussed and agreed on.  
+            catch (ResourceNotFoundException ex) {
+                LoggingHandler.LogInfo($"Organisation with id={id} was found, but could not be accessed from 'PauseOrganisation Gateway method.");
+                LoggingHandler.LogInfo($"Logged message:\n{ex.Message}");
+                if (ex.InnerException != null)
+                    LoggingHandler.LogInfo($"Logged inner message:\n{ex?.InnerException?.Message}");
+                throw ex; // terminate execution, force retry.
+            }
+            catch (Exception ex) {
+                LoggingHandler.LogInfo($"Unexpected exception occured while calling Pause Step use case with id={id}.");
+                LoggingHandler.LogInfo($"Logged message:\n{ex.Message}");
+                if (ex.InnerException != null)
+                    LoggingHandler.LogInfo($"Logged inner message:\n{ex?.InnerException?.Message}");
+                throw ex;
+            }
         }
     }
 }

--- a/LbhFssStepFunction.Tests/TestHelpers/Randomm.cs
+++ b/LbhFssStepFunction.Tests/TestHelpers/Randomm.cs
@@ -23,6 +23,16 @@ namespace LbhFssStepFunction.Tests.TestHelpers
         {
             return _faker.Random.Int(minimum, maximum);
         }
+        public static int Int(
+            int minimum = int.MinValue,
+            int maximum = int.MaxValue)
+        {
+            return _faker.Random.Int(minimum, maximum);
+        }
+        public static T EqualChanceItems<T>(params T[] possibilities)
+        {
+            return possibilities[Int(0, possibilities.Length - 1)];
+        }
         public static string Word()
         {
             return _faker.Random.Word();

--- a/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 using System;
 using LbhFssStepFunction.V1.Errors;
 using FluentAssertions;
+using LbhFssStepFunction.V1;
+using System.Linq;
 
 namespace LbhFssStepFunction.Tests.V1.UseCase
 {
@@ -28,62 +30,97 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         }
 
         [TestCase(TestName = @"
-            Given that the first step use case gets called,
-            It calls the organisation gateway GetOrganisationsToReview method.")]
+            Given an existing organisation id (the flag method doesn't throw),
+            When the first step use case gets called,
+            It calls the organisation gateway GetOrganisationsToReview method with correct id.")]
         public async Task FirstStepUseCaseCallsOrganisationGateway()
         {
             // arrange
-            _mockOrganisationGateway.Setup(
-                gw => gw.GetOrganisationById(It.IsAny<int>())).Returns(EntityHelpers.CreateOrganisation().ToDomain());
+            var organisation = EntityHelpers.CreateOrganisation(withId: true).ToDomain();
+            int existingId = organisation.Id;
+
+            _mockOrganisationGateway
+                .Setup(gw => gw.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(organisation);
             
             // act
-            await _classUnderTest.GetOrganisationAndSendEmail(1);
+            await _classUnderTest.GetOrganisationAndSendEmail(existingId);
             
             // assert
-            _mockOrganisationGateway.Verify(gw => gw.GetOrganisationById(It.IsAny<int>()), Times.Once);
+            _mockOrganisationGateway.Verify(
+                gw => gw.GetOrganisationById(It.Is<int>(id => id == existingId)),
+                Times.Once);
         }
 
         [TestCase(TestName = @"
-            Given that the first step use case gets called,
-            It calls the notify gateway SendNotificationEmail method.")]
+            Given an existing Organisation id,
+            When the first step use case gets called,
+            It calls the notify gateway SendNotificationEmail method,
+            And returns correct organisations and next step state data.")]
         public async Task FirstStepUseCaseCallsNotificationGateway()
         {
             // arrange
-            var organisation = EntityHelpers.CreateOrganisation();
-            _mockOrganisationGateway.Setup(og => og.GetOrganisationById(It.IsAny<int>())).Returns(organisation.ToDomain());
+            int waitDuration = Int32.Parse(Environment.GetEnvironmentVariable("WAIT_DURATION"));
+            var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true, activeUsers: true).ToDomain();
+            int existingId = organisation.Id;
+
+            _mockOrganisationGateway
+                .Setup(og => og.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(organisation);
+
+            var emailArgs = organisation.UserOrganisations.Select(uo => uo.User.Email).ToList();
 
             // act
-            await _classUnderTest.GetOrganisationAndSendEmail(1);
+            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(existingId);
             
             // assert
-            _mockNotifyGateway.Verify(gw => gw.SendNotificationEmail(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<int>()), Times.Once);
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.Is<string>(n => n == organisation.Name), 
+                    It.Is<string[]>(es => 
+                        es.All(e => emailArgs.Contains(e)) && 
+                        es.Count() == emailArgs.Count()), 
+                    It.Is<int>(state => state == 1)), 
+                Times.Once);
+
+            ucResult.Should().NotBeNull(); // If it's NULL crash right away
+            ucResult.EmailAddresses.Should().BeEquivalentTo(emailArgs);
+            // Next step time should be ±2 seconds from the time the UC was executed.
+            ucResult.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(waitDuration), precision: 2000);
+            ucResult.StateResult.Should().BeTrue();
+            ucResult.OrganisationId.Should().Be(existingId);
         }
 
-        // There should be a test case for UC return, but the current return doesn't make sense.
+        // There should be a test case for the correct UC return, but the current return doesn't make sense.
         // Will look into refactoring in the future.
 
         [TestCase(TestName = @"
             Given an existing organisation's Id (GW mock will not throw an error),
             When the first step usecase's GetOrganisationAndSendEmail method is called,
-            Then the secondary call to FlagOrganisationToBeInRevalidation organition gateway's method is made")]
+            Then the secondary call to FlagOrganisationToBeInRevalidation organition gateway's method is made,
+            And the passed in parameters are correct.")]
         public async Task FirstStepUCCallsFlagOrgMethod()
         {
             // arrange
-            int randomOrgId = Randomm.Id(100, 200);
-            _mockOrganisationGateway.Setup(
-                gw => gw.GetOrganisationById(It.IsAny<int>())).Returns(EntityHelpers.CreateOrganisation().ToDomain());
+            int existingId = Randomm.Id(100, 200);
+            _mockOrganisationGateway
+                .Setup(gw => gw.GetOrganisationById(It.IsAny<int>()))
+                .Returns(EntityHelpers.CreateOrganisation().ToDomain());
 
             // act
-            await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
+            await _classUnderTest.GetOrganisationAndSendEmail(existingId);
 
             // assert
-            _mockOrganisationGateway.Verify(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()), Times.Once);
+            _mockOrganisationGateway.Verify(
+                gw => gw.FlagOrganisationToBeInRevalidation(It.Is<int>(id => id == existingId)),
+                Times.Once);
         }
 
         [TestCase(TestName = @"
-            Given an existing organisation's Id (GW mock will not throw an error),
+            Given a NOT existing organisation's Id (organisations GW mock WILL throw an error),
             When the first step usecase's GetOrganisationAndSendEmail method is called,
-            Then the secondary call to FlagOrganisationToBeInRevalidation organition gateway's method is made")]
+            Then the use case captures FlagOrganisationToBeInRevalidation organition gateway's method failure,
+            And the UC returns NULL result.")]
         public async Task FirstStepUCReturnsNullWhenFlagOrgMethodThrowsResourceNotFound()
         {
             // arrange
@@ -91,12 +128,25 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             _mockOrganisationGateway.Setup(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()))
                 .Throws(new ResourceNotFoundException("Error"));
             
-            // act
-            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
+            // act, assert
+            Func<Task<OrganisationResponse>> ucCall = async () =>
+                await _classUnderTest.GetOrganisationAndSendEmail(randomOrgId);
+            
+            ucCall.Should().NotThrow();
+            
+            var ucResult = await ucCall();
+            ucResult.Should().BeNull();
 
-            // assert
-            _mockOrganisationGateway.Verify(gw => gw.FlagOrganisationToBeInRevalidation(It.IsAny<int>()), Times.Once);
-            ucResult.Should().Be(null);
+            _mockOrganisationGateway.Verify(
+                gw => gw.GetOrganisationById(It.IsAny<int>()),
+                Times.Never);
+
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<int>()),
+                Times.Never);
         }
     }
 }

--- a/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
@@ -159,6 +159,7 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             Given a NOT existing Organisation Id,
             When the Pause Step Usecase gets called,
             Then it does NOT call SendNotfication notify gateway's method,
+            And it does NOT call PauseOrganisation organisation gateway's method,
             And it returns a NULL result.")]
         public async Task PauseStepUCDoesNotCallNotifyGWAndReturnsNullWhenOrganisationIsNotFound()
         {
@@ -180,6 +181,10 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
                     It.IsAny<string>(),
                     It.IsAny<string[]>(),
                     It.IsAny<int>()),
+                Times.Never);
+
+            _mockOrganisationGateway.Verify(
+                gw => gw.PauseOrganisation(It.IsAny<int>()),
                 Times.Never);
             
             ucResult.Should().BeNull();
@@ -223,7 +228,6 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             ucCall.Should().Throw<ResourceNotFoundException>().WithMessage("Error");
             // Throw exception back to ensure that retry is scheduled.
         }
-
         // There should also be logging tests, however this would be going too far in terms of the ticket work
     }
 }

--- a/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
 using LbhFssStepFunction.Tests.TestHelpers;
+using LbhFssStepFunction.V1.Domains;
+using LbhFssStepFunction.V1.Errors;
 using LbhFssStepFunction.V1.Factories;
 using LbhFssStepFunction.V1.Gateways.Interface;
 using LbhFssStepFunction.V1.UseCase;
@@ -22,30 +28,202 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             _classUnderTest = new PauseStepUseCase(_mockOrganisationGateway.Object, _mockNotifyGateway.Object);
         }
 
-        [TestCase(TestName = "Given that the pause step use case gets called, it calls the organisation gateway GetOrganisationsToReview method.")]
-        public void PauseStepUseCaseCallsOrganisationGateway()
+        [TestCase(TestName = @"
+            Given any input organisation id,
+            When the Pause Step use case gets called,
+            Then it calls the GetOrganisationsToReview organisation gateway method
+            With correct parameters.")]
+        public async Task PauseStepUseCaseCallsOrganisationGateway()
         {
-            _classUnderTest.GetOrganisationAndSendEmail(1);
-            _mockOrganisationGateway.Verify(gw => gw.GetOrganisationById(It.IsAny<int>()), Times.Once);
+            // arrange
+            int anyId = Randomm.Id();
+
+            // act
+            await _classUnderTest.GetOrganisationAndSendEmail(anyId);
+            
+            // assert
+            _mockOrganisationGateway.Verify(
+                gw => gw.GetOrganisationById(It.Is<int>(id => id == anyId)),
+                Times.Once);
         }
 
-        [TestCase(TestName = "Given that the pause step use case gets called, it calls the organisation gateway PauseOrganisation method.")]
-        public void PauseStepUseCaseCallsOrgnisationGatewayPauseMethod()
+        [TestCase(TestName = @"
+            Given an existing Organisation Id,
+            And that organisation being in Revalidation process,
+            When the Pause Step use case gets called,
+            Then it calls the PauseOrganisation organisation gateway method with Correct parameters.")]
+        public async Task PauseStepUseCaseCallsOrgnisationGatewayPauseMethodWithCorrectParameters()
         {
-            var organisation = EntityHelpers.CreateOrganisation();
-            _mockOrganisationGateway.Setup(og => og.GetOrganisationById(It.IsAny<int>())).Returns(organisation.ToDomain());
-            _classUnderTest.GetOrganisationAndSendEmail(1);
-            _mockOrganisationGateway.Verify(gw => gw.PauseOrganisation(It.IsAny<int>()), Times.Once);
+            // arrange
+            var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true);
+            int existingId = organisation.Id;
+            organisation.InRevalidationProcess = true;
+
+            var domainOrganisation = organisation.ToDomain();
+            
+            _mockOrganisationGateway
+                .Setup(og => og.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(domainOrganisation);
+
+            // act
+            await _classUnderTest.GetOrganisationAndSendEmail(existingId);
+            
+            // assert
+            _mockOrganisationGateway.Verify(
+                gw => gw.PauseOrganisation(It.Is<int>(id => id == existingId)),
+                Times.Once);
         }
 
-        [TestCase(TestName = "Given that the pause step use case gets called, it calls the notify gateway SendNotificationEmail method.")]
-        public void PauseStepUseCaseCallsNotificationGateway()
+        [TestCase(TestName = @"
+            Given an existing Organisation Id,
+            And that organisation being in Revalidation process, 
+            When the Pause Step use case gets called,
+            Then it calls the SendNotificationEmail notify gateway method with correct parameters,
+            And it returns the correct organisation & Next Step state data.")]
+        public async Task PauseStepUseCaseCallsNotificationGatewayWithCorrectParamsIfOrganisationWasNotUpdated()
         {
-            var organisation = EntityHelpers.CreateOrganisation();
-            _mockOrganisationGateway.Setup(og => og.GetOrganisationById(It.IsAny<int>())).Returns(organisation.ToDomain());
-            _classUnderTest.GetOrganisationAndSendEmail(1);
-            _mockNotifyGateway.Verify(gw => gw.SendNotificationEmail(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<int>()), Times.Once);
+            // arrange
+            var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true, activeUsers: true);
+            int existingId = organisation.Id;
+            // Implies that organisation wasn't updated since Step 3 was called.
+            organisation.InRevalidationProcess = true;
+
+            var expectedNotifyEmailArgs = organisation.UserOrganisations.Select(uo => uo.User.Email).ToList();
+
+            var domainOrganisation = organisation.ToDomain();
+            
+            _mockOrganisationGateway
+                .Setup(og => og.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(domainOrganisation);
+            
+            // act
+            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(existingId);
+            
+            // assert
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.Is<string>(n => n == domainOrganisation.Name), 
+                    It.Is<string[]>(es => 
+                        es.All(e => expectedNotifyEmailArgs.Contains(e)) && 
+                        es.Count() == expectedNotifyEmailArgs.Count()), 
+                    It.Is<int>(state => state == 4)), 
+                Times.Once);
+
+            ucResult.Should().NotBeNull();
+            ucResult.EmailAddresses.Should().BeEquivalentTo(expectedNotifyEmailArgs);
+            // Next step time should be ±2 seconds from the time the UC was executed. Should be accurate enough for testing purposes.
+            ucResult.StateResult.Should().BeTrue(); // indicate success //(default(bool));
+            ucResult.OrganisationId.Should().Be(existingId); // the rest of the organisations data is irrelevant.
+            ucResult.NextStepTime.Should().BeCloseTo(default(DateTime), precision: 2000); // shows datetime is irrelevant
         }
 
+        // existing not valid
+        [TestCase(TestName = @"
+            Given an existing Organisation Id,
+            And that organisation NOT being in Revalidation process,
+            When the Pause Step use case gets called,
+            Then it does NOT call the SendNotfication notify gateway's method,
+            And it returns a NULL result.")]
+        public async Task PauseStepUCDoesNotCallNotifyGWAndReturnsNullWhenOrganisationWasUpdated()
+        {
+            // arrange
+            var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true, activeUsers: true);
+            int existingId = organisation.Id;
+            
+            // This being false implies that organisation was updated between the Step 3 and Pause Step.
+            organisation.InRevalidationProcess = false;
+
+            var domainOrganisation = organisation.ToDomain();
+
+            _mockOrganisationGateway
+                .Setup(gw => gw.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(domainOrganisation);
+
+            // act
+            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(existingId);
+
+            // assert
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<int>()),
+                Times.Never);
+
+            ucResult.Should().BeNull();
+            // I think in this particular case it would make more sense to return 'false'
+            // since that's not so much an error, but rather an invalid operation.
+        }
+
+        [TestCase(TestName = @"
+            Given a NOT existing Organisation Id,
+            When the Pause Step Usecase gets called,
+            Then it does NOT call SendNotfication notify gateway's method,
+            And it returns a NULL result.")]
+        public async Task PauseStepUCDoesNotCallNotifyGWAndReturnsNullWhenOrganisationIsNotFound()
+        {
+            // arrange
+            int nonExistingId = Randomm.Id();
+            // organisation was deleted between the triggering of Step 3 and Pause Step.
+            OrganisationDomain organisation = null;
+
+            _mockOrganisationGateway
+                .Setup(gw => gw.GetOrganisationById(It.Is<int>(id => id == nonExistingId)))
+                .Returns(organisation);
+
+            // act
+            var ucResult = await _classUnderTest.GetOrganisationAndSendEmail(nonExistingId);
+
+            // assert
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<int>()),
+                Times.Never);
+            
+            ucResult.Should().BeNull();
+            // This one is well deserved NULL since we don't even know what the organisation is anymore.
+        }
+
+        [TestCase(TestName = @"
+            Given an existing organisation's Id,
+            In an unlikely case of organisation getting deleted or inaccessible immediatelly after retrieving it,
+            When the Pause Step use case's GetOrganisationAndSendEmail method is called,
+            And UC calls PauseOrganisation notify GW method, which throws an exception as a result,
+            Then the exception gets caught and NULL is returned.")]
+        public void PauseStepUCReturnsThrowsWhenPauseOrgMethodThrowsResourceNotFound()
+        {
+            // arrange
+            var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true, activeUsers: true);
+            int existingId = organisation.Id;
+            organisation.InRevalidationProcess = true; // we don't terminate immediatelly
+            var domainOrganisation = organisation.ToDomain();
+
+            _mockOrganisationGateway
+                .Setup(gw => gw.GetOrganisationById(It.Is<int>(id => id == existingId)))
+                .Returns(domainOrganisation);
+
+            int nonExistingId = existingId; // organisation gets deleted or inaccessible.
+            
+            _mockOrganisationGateway.Setup(gw => gw.PauseOrganisation(It.Is<int>(id => id == nonExistingId)))
+                .Throws(new ResourceNotFoundException("Error"));
+            
+            // act
+            Func<Task> ucCall = async () => await _classUnderTest.GetOrganisationAndSendEmail(existingId);
+
+            // assert
+            _mockNotifyGateway.Verify(
+                gw => gw.SendNotificationEmail(
+                    It.IsAny<string>(),
+                    It.IsAny<string[]>(),
+                    It.IsAny<int>()),
+                Times.Never);
+            
+            ucCall.Should().Throw<ResourceNotFoundException>().WithMessage("Error");
+            // Throw exception back to ensure that retry is scheduled.
+        }
+
+        // There should also be logging tests, however this would be going too far in terms of the ticket work
     }
 }

--- a/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/PauseStepUseCaseTests.cs
@@ -43,7 +43,6 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         {
             var organisation = EntityHelpers.CreateOrganisation();
             _mockOrganisationGateway.Setup(og => og.GetOrganisationById(It.IsAny<int>())).Returns(organisation.ToDomain());
-            _mockOrganisationGateway.Setup(og => og.PauseOrganisation(It.IsAny<int>())).Returns(organisation.ToDomain());
             _classUnderTest.GetOrganisationAndSendEmail(1);
             _mockNotifyGateway.Verify(gw => gw.SendNotificationEmail(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<int>()), Times.Once);
         }


### PR DESCRIPTION
# What:
 - Added Pause Step termination when an organisation has be re-verified since the execution of Step 3.
 - Improved the testing of Organisations gateway, as well as a couple steps' use cases.
 - Improved Pause Step use case logging.
 - Changed PauseOrganisation notify gateway method's signature for it to omit any returns.

# Why:
 - Same reasoning as for Steps 2 and 3, see PR: #2.
 - The methods signature change was done because the "Pause Organisation" method, strictly logically looking at it, is nothing but an operation with side effects. It shouldn't be returning organisation domain entity. So it would have two options of what it could be: 1) a void operation with no return, but it throws pre-defined exceptions should anything go wrong; 2) an operation returning boolean value representing its success status; Both implementation would require method signature rework. I chose option 1 as it better reflects the nature of the work being done by the operation. 

# Notes:
 - The definition of done for Start Step _(Step 0)_ is kind of vague. I'd argue that it does what it needs to do, but perhaps I'm not aware of all of the requirements. For this I need to have a catch up with certain members of the team. Should Step 0 need more work, there will be a PR following this one.