### PR TITLE
Serverless Fix

### DIFF
--- a/FSSStepFunction/serverless.yml
+++ b/FSSStepFunction/serverless.yml
@@ -3,10 +3,10 @@ provider:
   name: aws
   runtime: dotnetcore3.1
   timeout: 15
-  #vpc: ${self:custom.vpc.${opt:stage}}
-  #stage: ${opt:stage}
-  vpc: ${self:custom.vpc.development}
-  stage: development
+  vpc: ${self:custom.vpc.${opt:stage}}
+  stage: ${opt:stage}
+#  vpc: ${self:custom.vpc.development}
+#  stage: development
   region: eu-west-2
 
 package:


### PR DESCRIPTION
## What
- Update serverless config to allow deployments to parameter supplied stages.

## Why
- Serverless configuration was only being applied to the development environment.  This update will allow staging and production stages to be applied if specified.