### PR TITLE
Changes for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,27 +66,27 @@ commands:
             sls deploy --stage <<parameters.stage>>
 
 jobs:
-  check-code-formatting:
-    executor: docker-dotnet
+  # check-code-formatting:
+  #   executor: docker-dotnet
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Install dotnet format
+  #         command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
+  #     - run:
+  #         name: Run formatter check
+  #         command: ./dotnet-format-local/dotnet-format --dry-run
+  build-and-test:
+    executor: docker-python
     steps:
       - checkout
-#      - run:
-#          name: Install dotnet format
-#          command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-#      - run:
-#          name: Run formatter check
-#          command: ./dotnet-format-local/dotnet-format --dry-run
-   build-and-test:
-     executor: docker-python
-     steps:
-       - checkout
-       - setup_remote_docker
-       - run:
-           name: build
-           command: docker-compose build lbh-fss-portal-api-test
-       - run:
-           name: Run tests
-           command: docker-compose run lbh-fss-portal-api-test
+      - setup_remote_docker
+      - run:
+          name: build
+          command: docker-compose build lbh-fss-portal-api-test
+      - run:
+          name: Run tests
+          command: docker-compose run lbh-fss-portal-api-test
   assume-role-development:
     executor: docker-python
     steps:
@@ -121,10 +121,10 @@ jobs:
 workflows:
   check-and-deploy-development:
     jobs:
-      - check-code-formatting:
-        filters:
-          branches:
-            ignore: master
+      # - check-code-formatting:
+      #   filters:
+      #     branches:
+      #       ignore: master
       - build-and-test:
         filters:
           branches:
@@ -144,14 +144,14 @@ workflows:
               ignore: master
   check-and-deploy-staging-and-production:
     jobs:
-      #      - build-and-test:
-      #          filters:
-      #            branches:
-      #              only: master
+      - build-and-test:
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
-          #          requires:
-          #            - build-and-test
+          requires:
+            - build-and-test
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Run tests
-          command: make test
+          command: make test-cci
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,17 +76,17 @@ jobs:
 #      - run:
 #          name: Run formatter check
 #          command: ./dotnet-format-local/dotnet-format --dry-run
-  #  build-and-test:
-  #    executor: docker-python
-  #    steps:
-  #      - checkout
-  #      - setup_remote_docker
-  #      - run:
-  #          name: build
-  #          command: docker-compose build lbh-fss-portal-api-test
-  #      - run:
-  #          name: Run tests
-  #          command: docker-compose run lbh-fss-portal-api-test
+   build-and-test:
+     executor: docker-python
+     steps:
+       - checkout
+       - setup_remote_docker
+       - run:
+           name: build
+           command: docker-compose build lbh-fss-portal-api-test
+       - run:
+           name: Run tests
+           command: docker-compose run lbh-fss-portal-api-test
   assume-role-development:
     executor: docker-python
     steps:
@@ -125,14 +125,14 @@ workflows:
         filters:
           branches:
             ignore: master
-      #      - build-and-test:
-      #        filters:
-      #          branches:
-      #            ignore: master
+      - build-and-test:
+        filters:
+          branches:
+            ignore: master
       - assume-role-development:
           context: api-assume-role-development-context
-          #          requires:
-          #            - build-and-test
+          requires:
+            - build-and-test
           filters:
             branches:
               ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,11 +82,8 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: build
-          command: docker-compose build lbh-fss-portal-api-test
-      - run:
           name: Run tests
-          command: docker-compose run lbh-fss-portal-api-test
+          command: make test
   assume-role-development:
     executor: docker-python
     steps:

--- a/FSSStepFunction/V1/Helpers/SharedUtils.cs
+++ b/FSSStepFunction/V1/Helpers/SharedUtils.cs
@@ -11,8 +11,8 @@ namespace LbhFssStepFunction.V1.Helpers
                     message: $"The wait time string was not provided, or provided empty: '{waitTime ?? "null"}'.",
                     paramName: nameof(waitTime));
 
-            int waitDurationDays;
-            bool success = int.TryParse(waitTime, out waitDurationDays);
+            double waitDurationDays;
+            bool success = Double.TryParse(waitTime, out waitDurationDays);
             
             if(!success) throw new FormatException(
                 $"The wait time string: '{waitTime}' is not numeric, hence could not be parsed.");

--- a/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
+++ b/LbhFssStepFunction.Tests/V1/UseCase/FirstStepUseCaseTests.cs
@@ -23,7 +23,7 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         [SetUp]
         public void Setup()
         {
-            Environment.SetEnvironmentVariable("WAIT_DURATION", "600");
+            Environment.SetEnvironmentVariable("WAIT_DURATION", "10.5");
             _mockOrganisationGateway = new Mock<IOrganisationsGateway>();
             _mockNotifyGateway = new Mock<INotifyGateway>();
             _classUnderTest = new FirstStepUseCase(_mockOrganisationGateway.Object, _mockNotifyGateway.Object);
@@ -60,7 +60,7 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
         public async Task FirstStepUseCaseCallsNotificationGateway()
         {
             // arrange
-            int waitDuration = Int32.Parse(Environment.GetEnvironmentVariable("WAIT_DURATION"));
+            double waitDuration = Double.Parse(Environment.GetEnvironmentVariable("WAIT_DURATION"));
             var organisation = EntityHelpers.CreateOrganisationWithUsers(withIds: true, activeUsers: true).ToDomain();
             int existingId = organisation.Id;
 
@@ -86,7 +86,7 @@ namespace LbhFssStepFunction.Tests.V1.UseCase
             ucResult.Should().NotBeNull(); // If it's NULL crash right away
             ucResult.EmailAddresses.Should().BeEquivalentTo(emailArgs);
             // Next step time should be ±2 seconds from the time the UC was executed.
-            ucResult.NextStepTime.Should().BeCloseTo(DateTime.Now.AddSeconds(waitDuration), precision: 2000);
+            ucResult.NextStepTime.Should().BeCloseTo(DateTime.Now.AddDays(waitDuration), precision: 2000);
             ucResult.StateResult.Should().BeTrue();
             ucResult.OrganisationId.Should().Be(existingId);
         }

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ setup:
 .PHONY: test
 test:
 	docker-compose up test-database & docker-compose build lbh-fss-step-function-test && docker-compose up lbh-fss-step-function-test
+
+.PHONY: test-cci
+test-cci:
+	docker-compose run lbh-fss-step-function-test

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@
 setup:
 	docker-compose build
 
-.PHONY: build
-build:
-	docker-compose build lbh-fss-step-function
-
 .PHONY: test
 test:
 	docker-compose up test-database & docker-compose build lbh-fss-step-function-test && docker-compose up lbh-fss-step-function-test

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,1 +1,1 @@
-FROM postgres:12
+FROM postgres:12-buster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword
       - DB_DATABASE=testdb
-#    links:
-#      - test-database
+    links:
+      - test-database
   test-database:
     image: test-database
     build:


### PR DESCRIPTION
# What:
 - Made the Next Step run date calculator accept values with decimal point.
 - Fixed the docker-compose container linking between test and database containers.
 - Specified a working database image version.
 - Enabled the "Run Unit Tests" step in the repository's pipeline.
 - Moved out the run tests command to Makefile so the code would be less scattered.

# Why:
 - While we don't need decimal point wait time values for live (production) environment, we do need them so we could perform E2E smoke testing as waiting 1 day per step would not be feasible.
 - Fixed the automated tests step of the pipeline so we could capture any potential errors that do not show up locally.
 - The database image version had to be changed as the previous one had issues with establishing the connection with tests container.

# Notes:
 - Despite the wait time string being expected to be a number with a decimal point, it does not have to be. Integer numbers will properly parsed as well. So if the wait time is specified as "14" days, it will get parsed to "14.0" days.
 - For testing purposes, the wanted time in seconds will need to be expressed in days. So, if you need 1 second between the steps, then do the calculation: `1s = 1 * [s] = 1* 1/60 * [min] = 1 * 1/60 * 1/60 * [hour] = 1/3600 * 1/24 * [day] = 1/86400 [day] = 0.000011574 [day]`.
 - **Or should you need, say 50 seconds between steps, then just calculate:** `50 * 1/86400 [day] = 50/86400 [day] = 0.000578704 [day](s)`