### PR TITLE
Enable deployment past development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,13 +132,13 @@ workflows:
             - build-and-test
           filters:
             branches:
-              ignore: master
+              only: develop
       - deploy-to-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              ignore: master
+              only: develop
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:

--- a/FSSStepFunction/serverless.yml
+++ b/FSSStepFunction/serverless.yml
@@ -3,10 +3,8 @@ provider:
   name: aws
   runtime: dotnetcore3.1
   timeout: 30
-  #vpc: ${self:custom.vpc.${opt:stage}}
-  #stage: ${opt:stage}
-  vpc: ${self:custom.vpc.development}
-  stage: development
+  vpc: ${self:custom.vpc.${opt:stage}}
+  stage: ${opt:stage}
   region: eu-west-2
   environment:
     CONNECTION_STRING: Host=${ssm:/fss-public-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/fss-public-api/${self:provider.stage}/postgres-port};Database=${ssm:/fss-public-api/${self:provider.stage}/postgres-database};Username=${ssm:/fss-public-api/${self:provider.stage}/postgres-username};Password=${ssm:/fss-public-api/${self:provider.stage}/postgres-password}

--- a/FSSStepFunction/serverless.yml
+++ b/FSSStepFunction/serverless.yml
@@ -4,18 +4,17 @@ provider:
   runtime: dotnetcore3.1
   timeout: 30
   vpc: ${self:custom.vpc.${opt:stage}}
-  stage: ${opt:stage}
   region: eu-west-2
   environment:
-    CONNECTION_STRING: Host=${ssm:/fss-public-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/fss-public-api/${self:provider.stage}/postgres-port};Database=${ssm:/fss-public-api/${self:provider.stage}/postgres-database};Username=${ssm:/fss-public-api/${self:provider.stage}/postgres-username};Password=${ssm:/fss-public-api/${self:provider.stage}/postgres-password}
-    NOTIFY_KEY: ${ssm:/fss-portal-api/${self:provider.stage}/notify-key}
-    ACCESS_ID: ${ssm:/fss-portal-api/${self:provider.stage}/cognito-user}
-    ACCESS_KEY: ${ssm:/fss-portal-api/${self:provider.stage}/cognito-key}
-    REVERIFICATION_FIRST_EMAIL_TEMPLATE: ${ssm:/fss-common/${self:provider.stage}/reverification-first-email-template}
-    REVERIFICATION_SECOND_EMAIL_TEMPLATE: ${ssm:/fss-common/${self:provider.stage}/reverification-second-email-template}
-    REVERIFICATION_THIRD_EMAIL_TEMPLATE: ${ssm:/fss-common/${self:provider.stage}/reverification-third-email-template}
-    REVERIFICATION_PAUSE_EMAIL_TEMPLATE: ${ssm:/fss-common/${self:provider.stage}/reverification-pause-email-template}
-    WAIT_DURATION: ${ssm:/fss-step-function/${self:provider.stage}/wait-duration}
+    CONNECTION_STRING: Host=${ssm:/fss-public-api/${opt:stage}/postgres-hostname};Port=${ssm:/fss-public-api/${opt:stage}/postgres-port};Database=${ssm:/fss-public-api/${opt:stage}/postgres-database};Username=${ssm:/fss-public-api/${opt:stage}/postgres-username};Password=${ssm:/fss-public-api/${opt:stage}/postgres-password}
+    NOTIFY_KEY: ${ssm:/fss-portal-api/${opt:stage}/notify-key}
+    ACCESS_ID: ${ssm:/fss-portal-api/${opt:stage}/cognito-user}
+    ACCESS_KEY: ${ssm:/fss-portal-api/${opt:stage}/cognito-key}
+    REVERIFICATION_FIRST_EMAIL_TEMPLATE: ${ssm:/fss-common/${opt:stage}/reverification-first-email-template}
+    REVERIFICATION_SECOND_EMAIL_TEMPLATE: ${ssm:/fss-common/${opt:stage}/reverification-second-email-template}
+    REVERIFICATION_THIRD_EMAIL_TEMPLATE: ${ssm:/fss-common/${opt:stage}/reverification-third-email-template}
+    REVERIFICATION_PAUSE_EMAIL_TEMPLATE: ${ssm:/fss-common/${opt:stage}/reverification-pause-email-template}
+    WAIT_DURATION: ${ssm:/fss-step-function/${opt:stage}/wait-duration}
 
 package:
   # individually: true
@@ -149,7 +148,7 @@ resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /${self:service}/${self:provider.stage}/
+        Path: /${self:service}/${opt:stage}/
         RoleName: ${self:service}-lambdaExecutionRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'


### PR DESCRIPTION
# What:
 - Stopped `deploy to development` and `assume role ...`  steps from triggering on feature branches.
 - Parameterized the `stage` and `vpc` variables within the serverless yaml config.
 - Fixed an issue where the `provider.stage` value would fail to set due to `opt:stage` for some reason being not initialized yet.

# Why:
 - Deployment shouldn't trigger on feature branches, because we don't want every deploy to feature override the deployment that actually needs testing once the merge to `develop` branch happens. Also parallel work on multiple feature branches would keep overwriting the development environment.
 - Did the rest of fixes, adjustments so that the pipeline wouldn't be hard-coded to only being able to deploy to `development` environment.

# Notes:
 - The `provider.stage` not being able to set is weird issue. As far as I've looked into documentation & etc. it doesn't seem to be a configuration problem. Must be a bug within the version of SLS we're using or something. Hard to tell.

| Serverless YAML variable resolution error |
| :------: |
| ![image](https://user-images.githubusercontent.com/43747286/160142680-dc430db6-75bf-4aaf-b090-44cccaf29dfc.png) |

 - This a continuation of the PR #5 , except on a different branch-out point.