### PR TITLE
Fix delayed live deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,6 @@ workflows:
           filters:
             branches:
               only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
       - permit-production-release:
           type: approval
           requires:
@@ -172,9 +165,15 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy-to-production:
+      - assume-role-production:
+          context: api-assume-role-production-context
           requires:
             - permit-production-release
+          filters:
+            branches:
+              only: master
+      - deploy-to-production:
+          requires:
             - assume-role-production
           filters:
             branches:


### PR DESCRIPTION
# What:
 - Made the retrieval of temporary credentials happen only when the approval for deployment to production is given.

# Why:
 - Because the temporary credentials only last for so long. For the pipeline prior to this PR to work, the deployment to production has to be done almost immediately after deployment to staging. This leaves no time for testing on staging environment. So to avoid having to rerun the whole pipeline due to expired credentials, it's better to just tweak it so the retrieval of credentials happens after user permits deployment to live, not before.

# Notes:
 - In my particular case, I need some time to test things out on staging environment, as well as to tweak environment variables on live.